### PR TITLE
Fix Main Window VEC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ output*
 *txt
 *csv
 makefile
+doc/*

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ IRC Network in the #efbgen channel.  IRC address is irc.oftc.net ... you
 can connect via Port 6667 for non-secure, or use Port 6697 for SSL.
 
 ## changelog
+v 0.1.1 - Fix VEC labels
+  - Label for "Regional Identifier" was missing the colon, and all
+    labels now have a space between the 'title' and the value.
+ 
 v 0.1.0 - Stable Beta
   - Should be stable now.  Future patches, etc. based on user experience
     requests

--- a/ebfgen.py
+++ b/ebfgen.py
@@ -228,16 +228,18 @@ class Window(Frame):
       frame_c=tk.Frame(self.master)
 
       vec_sec = tk.Label(frame_a, text="Session & VEC Information")
-      self.l_VEC = tk.Label(frame_a, text="VEC Code:" + VEC)
-      self.l_sess = tk.Label(frame_a, text="Session Date:"+ sdt)
-      self.l_city = tk.Label(frame_a, text="Exam City:"+ vecity)
-      self.l_state = tk.Label(frame_a, text="Exam State:" + vestate.get())
-      self.l_appT = tk.Label(frame_a, text="Applicants Tested:"+ appt)
-      self.l_appP = tk.Label(frame_a, text="Applicants Passed:"+ appp)
-      self.l_appF = tk.Label(frame_a, text="Applicants Failed:"+ appf)
-      self.l_elmP = tk.Label(frame_a, text="Elements Passed:"+ elmp)
-      self.l_elmF = tk.Label(frame_a, text="Elements Failed:"+ elmf)
-      self.l_tloc = tk.Label(frame_a, text="Regional Identifier"+tloc)
+      self.l_VEC = tk.Label(frame_a, text="VEC Code: " + VEC)
+      self.l_sess = tk.Label(frame_a, text="Session Date: "+ sdt)
+      self.l_city = tk.Label(frame_a, text="Exam City: "+ vecity)
+      self.l_state = tk.Label(frame_a, text="Exam State: "\
+        + vestate.get())
+      self.l_appT = tk.Label(frame_a, text="Applicants Tested: "+ appt)
+      self.l_appP = tk.Label(frame_a, text="Applicants Passed: "+ appp)
+      self.l_appF = tk.Label(frame_a, text="Applicants Failed: "+ appf)
+      self.l_elmP = tk.Label(frame_a, text="Elements Passed: "+ elmp)
+      self.l_elmF = tk.Label(frame_a, text="Elements Failed: "+ elmf)
+      self.l_tloc = tk.Label(frame_a, text="Regional Identifier: "\
+        + tloc)
 
       vec_sec.pack()
       self.l_VEC.pack()


### PR DESCRIPTION
Main VEC labels were missing spaces between the "title:" and "value", so
that's been added.  (e.g. from "VEC:x" to "VEC: x")